### PR TITLE
Bug/45 add units font sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --ext .js,.ts ./src",
     "prettier": "prettier --write \"(src|bin)/**/*.+(js|ts|json)\"",
     "start": "tsc-watch --onSuccess \"node .\"",
-    "run": "tsc; node .",
+    "once": "tsc; node .",
     "test": "jest"
   },
   "types": "./build/index.d.ts",

--- a/src/style-dictionary/parsers/tokensStudioParser.ts
+++ b/src/style-dictionary/parsers/tokensStudioParser.ts
@@ -25,15 +25,27 @@ function parseDesignToken(
     case 'spacing':
       parsedType = TokenType.space
       break
+    case 'dimension':
     case 'sizing':
       parsedType = TokenType.size
+      break
+    case 'lineHeights':
+      parsedType = TokenType.lineHeight
       break
     case 'textCase':
       parsedType = TokenType.textTransform
       break
+    case 'fontFamilies':
+      parsedType = TokenType.fontFamily
+      break;
+    case 'fontWeights':
+      parsedType = TokenType.fontWeight
+      break;
+    case 'fontSizes':
+      parsedType = TokenType.fontSize
+      break;
     case 'paragraphSpacing':
     case 'implicit':
-    case 'textDecoration':
       return null
     case 'other':
       /** The "other" tokens are identified by a keyword on their name */

--- a/src/style-dictionary/transform-groups.ts
+++ b/src/style-dictionary/transform-groups.ts
@@ -19,7 +19,6 @@ const webTransformers = [
   Transformer.parseAspectRatioWeb,
   Transformer.parseShadowValueWeb,
   Transformer.toLowerCase,
-  Transformer.transformToRem,
 ]
 
 /**

--- a/src/style-dictionary/transformers.ts
+++ b/src/style-dictionary/transformers.ts
@@ -8,38 +8,40 @@ import {
   ShadowTokenSingleValue,
   ShadowType,
 } from './types'
-import { toNumber } from '../utils/utils'
+import { addPxUnit, toNumber } from '../utils/utils'
 
-const typesWithDefaultPxUnit: TokenType[] = []
+const typesWithDefaultPxUnit: TokenType[] = [
+  TokenType.borderRadius,
+  TokenType.borderWidth,
+  TokenType.breakpoint,
+  TokenType.fontSize,
+  TokenType.letterSpacing,
+  TokenType.lineHeight,
+  TokenType.size,
+  TokenType.space,
+]
 
 const typesWithRemUnit: TokenType[] = [
   TokenType.borderRadius,
   TokenType.borderWidth,
+  TokenType.breakpoint,
+  TokenType.fontSize,
+  TokenType.letterSpacing,
+  TokenType.lineHeight,
   TokenType.size,
   TokenType.space,
-  TokenType.fontSize,
-  TokenType.lineHeight,
-  TokenType.letterSpacing,
-  TokenType.breakpoint,
 ]
 
 const typesWithMsDefaultUnit: TokenType[] = [TokenType.motionDuration]
 
 const typesWithKeywordValues: TokenType[] = [
-  TokenType.letterSpacing,
-  TokenType.textTransform,
-  TokenType.lineHeight,
   TokenType.fontWeight,
+  TokenType.letterSpacing,
+  TokenType.lineHeight,
   TokenType.motionEasing,
+  TokenType.textTransform,
+  TokenType.textDecoration,
 ]
-
-/*
-  - Transform px to rems in typography, spaces and sizes
-  - Add px to breakpoints
-  
-  - Shadow
-  - Typography
-*/
 
 /**
  * Checks if a token should be added the 'px' unit at the end
@@ -97,11 +99,11 @@ function transformToRemMatcher(token: TransformedToken): boolean {
 function transformSingleShadowValueWeb(
   shadowValue: ShadowTokenSingleValue
 ): string {
-  const offsetX = transformToRem(shadowValue.x)
-  const offsetY = transformToRem(shadowValue.y)
-  const blur = transformToRem(shadowValue.blur)
+  const offsetX = addPxUnit(shadowValue.x)
+  const offsetY = addPxUnit(shadowValue.y)
+  const blur = addPxUnit(shadowValue.blur)
   const color = shadowValue.color
-  const spread = transformToRem(shadowValue.spread)
+  const spread = shadowValue.spread
   const insetString =
     shadowValue.type === ShadowType.innerShadow ? 'inset ' : ''
   return `${insetString}${offsetX} ${offsetY} ${blur} ${spread} ${color}`

--- a/src/style-dictionary/types.ts
+++ b/src/style-dictionary/types.ts
@@ -48,6 +48,7 @@ export enum TokenType {
   size = 'size',
   space = 'space',
   textTransform = 'textTransform',
+  textDecoration = 'textDecoration',
   opacity = 'opacity',
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+const digitsRE = /[-+]?\d+(\.\d+)?/;
+
 /**
  * Consolidates a value that may be a string or a number (token) into a number,
  * extracting only the digits from a string
@@ -9,12 +11,32 @@ export function toNumber(value: string | number): number {
   if (typeof value === 'number') {
     return value
   } else {
-    const digitMatch = value.match(/[-+]?\d+(\.\d+)?/)
+    const digitMatch = value.match(digitsRE)
     if (!digitMatch) {
       return 0
     }
     return parseFloat(digitMatch[0])
   }
+}
+
+/**
+ * Adds 'px' at the end of `value` only if `value` != 0
+ * @param value 
+ * @return string `${value}px` or `${value}` if it's 0
+ */
+export function addPxUnit(value : number | string): string {
+  if (typeof value === 'number') {
+    return value === 0 ? `${value}` : `${value}px`;
+  }
+
+  // It's a string
+  const onlyNumbers = value.match(digitsRE);
+  if (!onlyNumbers) {
+    // If it already has a unit (not just a number) we don't add anything
+    return value;
+  }
+
+  return value === '0' ? value : `${value}px`
 }
 
 /**


### PR DESCRIPTION
Solves #45

Converts updated TokensStudio types to the types the FTE uses throughout its transforms. 

Also removes default rem conversion of unitless values and just adds pxs to correspondent tokens.